### PR TITLE
KspModules Consolidation & Add micronaut example

### DIFF
--- a/example/kotlinlib/basic/8-micronaut/build.mill
+++ b/example/kotlinlib/basic/8-micronaut/build.mill
@@ -1,0 +1,69 @@
+package build
+
+import coursier.{MavenRepository, Repository}
+
+import mill.*
+import kotlinlib.*
+import kotlinlib.ksp.Ksp2Module
+
+object micronaut extends MicronautModule {
+
+  override def repositoriesTask: Task[Seq[Repository]] = Task.Anon {
+    super.repositoriesTask() ++
+      Seq(MavenRepository.apply("https://plugins.gradle.org/m2"))
+  }
+
+  def mvnDeps: Task.Simple[Seq[Dep]] = Seq(
+    mvn"io.micronaut:micronaut-http-server-netty",
+    mvn"io.micronaut.serde:micronaut-serde-jackson",
+    mvn"ch.qos.logback:logback-classic:1.5.3",
+    mvn"io.micronaut.kotlin:micronaut-kotlin-runtime"
+  )
+
+  object test extends Ksp2Tests, TestModule.Junit5 {
+
+    def mvnDeps = super.mvnDeps() ++ Seq(
+      mvn"io.micronaut:micronaut-http-client",
+      mvn"io.micronaut.test:micronaut-test-junit5",
+      mvn"io.micronaut.kotlin:micronaut-kotlin-runtime"
+    )
+
+    def kotlinSymbolProcessors = Seq(
+      mvn"io.micronaut:micronaut-inject-kotlin:4.9.9",
+      mvn"io.micronaut:micronaut-inject-kotlin-test:4.9.9"
+    )
+
+    override def kspProcessorOptions: T[Map[String, String]] = Task {
+      super.kspProcessorOptions() ++ Map(
+        "micronaut.processing.module" -> moduleSegments.render,
+        "micronaut.processing.incremental" -> "true"
+      )
+    }
+
+    override def resources: T[Seq[PathRef]] = Task {
+      super.resources() ++ Seq(generatedSourcesWithKSP().resources)
+    }
+
+    override def runClasspath: T[Seq[PathRef]] = Task {
+      super.runClasspath() ++ Seq(generatedSourcesWithKSP().classes)
+    }
+
+  }
+
+  // Micronaut test not compatible with running in parallel
+  def testParallelism = false
+}
+
+trait MicronautModule extends Ksp2Module {
+  def kspVersion: T[String] = "2.0.2"
+  def kspJvmTarget: T[String] = "11"
+  def kotlinVersion = "2.2.0"
+
+  def kspLanguageVersion = "2.0"
+  def kspApiVersion = "2.0"
+
+  def bomMvnDeps: T[Seq[Dep]] = Seq(
+    mvn"io.micronaut.platform:micronaut-platform:4.9.2"
+  )
+
+}

--- a/example/kotlinlib/basic/8-micronaut/micronaut/src/micronaut/Micronaut.kt
+++ b/example/kotlinlib/basic/8-micronaut/micronaut/src/micronaut/Micronaut.kt
@@ -1,0 +1,6 @@
+package micronaut
+
+import io.micronaut.runtime.Micronaut.run
+fun main(args: Array<String>) {
+    run(*args)
+}

--- a/example/kotlinlib/basic/8-micronaut/micronaut/test/src/micronaut/FnrSearchServiceTest.kt.kt
+++ b/example/kotlinlib/basic/8-micronaut/micronaut/test/src/micronaut/FnrSearchServiceTest.kt.kt
@@ -1,0 +1,19 @@
+package micronaut
+
+import io.micronaut.runtime.EmbeddedApplication
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class FnrSearchServiceTest {
+
+    @Inject
+    lateinit var application: EmbeddedApplication<*>
+
+    @Test
+    fun testItWorks() {
+        Assertions.assertTrue(application.isRunning)
+    }
+}

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -1,14 +1,14 @@
 package build
 
 import mill.*, androidlib.*, kotlinlib.*
-import kotlinlib.ksp.*
+import kotlinlib.ksp.Ksp2Module
 import hilt.AndroidHiltSupport
 
 object Versions {
-  val kotlinVersion = "2.0.21"
-  val kotlinLanguageVersion = "1.9"
+  val kotlinVersion = "2.2.0"
+  val kotlinLanguageVersion = "2.0"
 
-  val kspVersion = "1.0.28"
+  val kspVersion = "2.0.2"
   val androidCompileSdk = 35
   val androidMinSdk = 26
 }
@@ -20,7 +20,7 @@ object androidSdkModule0 extends AndroidSdkModule {
 
 // Mill configuration for the Android Todo App project.
 object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfig,
-      KspModule, AndroidHiltSupport {
+      Ksp2Module, AndroidHiltSupport {
 
   def kotlinVersion = Versions.kotlinVersion
   def kotlinLanguageVersion = Versions.kotlinLanguageVersion
@@ -70,8 +70,8 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
     mvn"org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0",
     mvn"com.jakewharton.timber:timber:5.0.1",
     mvn"androidx.test.espresso:espresso-idling-resource:3.6.1",
-    mvn"androidx.room:room-runtime:2.6.1",
-    mvn"androidx.room:room-ktx:2.6.1",
+    mvn"androidx.room:room-runtime:2.7.1",
+    mvn"androidx.room:room-ktx:2.7.1",
     mvn"androidx.activity:activity-compose:1.10.0",
     mvn"androidx.navigation:navigation-compose:2.8.5",
     mvn"androidx.emoji2:emoji2:1.3.0",
@@ -105,11 +105,11 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
   )
 
   def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-    mvn"androidx.room:room-compiler:2.6.1",
+    mvn"androidx.room:room-compiler:2.7.1",
     mvn"com.google.dagger:hilt-android-compiler:2.56"
   )
 
-  object test extends AndroidAppKotlinTests, KspModule, AndroidHiltSupport, TestModule.Junit4 {
+  object test extends AndroidAppKotlinTests, Ksp2Module, AndroidHiltSupport, TestModule.Junit4 {
 
     def moduleDeps = super.moduleDeps ++ Seq(`shared-test`)
 
@@ -118,7 +118,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
     override def kspVersion = Versions.kspVersion
 
     def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-      mvn"androidx.room:room-compiler:2.6.1",
+      mvn"androidx.room:room-compiler:2.7.1",
       mvn"com.google.dagger:hilt-android-compiler:2.56"
     )
 
@@ -146,7 +146,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
   }
 
   object androidTest extends AndroidAppKotlinInstrumentedTests, AndroidR8AppModule,
-        KspModule, AndroidHiltSupport {
+        Ksp2Module, AndroidHiltSupport {
 
     override def kotlinLanguageVersion = Versions.kotlinLanguageVersion
 
@@ -191,7 +191,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
       mvn"androidx.test:core-ktx:1.6.1",
       mvn"androidx.test.ext:junit-ktx:1.2.1",
       mvn"androidx.test:rules:1.6.1",
-      mvn"androidx.room:room-testing:2.6.1",
+      mvn"androidx.room:room-testing:2.7.1",
       mvn"androidx.arch.core:core-testing:2.2.0",
       mvn"androidx.navigation:navigation-testing:2.8.5",
       mvn"androidx.test.espresso:espresso-core:3.6.1",
@@ -204,7 +204,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
     )
 
     def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-      mvn"androidx.room:room-compiler:2.6.1",
+      mvn"androidx.room:room-compiler:2.7.1",
       mvn"com.google.dagger:hilt-android-compiler:2.56"
     )
 
@@ -212,7 +212,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
 
 }
 
-object `shared-test` extends AndroidKotlinModule, KspModule, AndroidHiltSupport {
+object `shared-test` extends AndroidKotlinModule, Ksp2Module, AndroidHiltSupport {
 
   def moduleDeps = Seq(app)
 
@@ -230,7 +230,7 @@ object `shared-test` extends AndroidKotlinModule, KspModule, AndroidHiltSupport 
   def androidNamespace = "com.example.android.architecture.blueprints.todoapp.daemon.test"
 
   def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-    mvn"androidx.room:room-compiler:2.6.1",
+    mvn"androidx.room:room-compiler:2.7.1",
     mvn"com.google.dagger:hilt-android-compiler:2.56"
   )
 
@@ -244,8 +244,8 @@ object `shared-test` extends AndroidKotlinModule, KspModule, AndroidHiltSupport 
     mvn"androidx.test:rules:1.6.1",
     mvn"com.google.dagger:hilt-android:2.56",
     mvn"com.google.dagger:hilt-android-testing:2.56",
-    mvn"androidx.room:room-runtime:2.6.1",
-    mvn"androidx.room:room-ktx:2.6.1"
+    mvn"androidx.room:room-runtime:2.7.1",
+    mvn"androidx.room:room-ktx:2.7.1"
   )
 }
 

--- a/example/thirdparty/androidtodo/build.mill
+++ b/example/thirdparty/androidtodo/build.mill
@@ -1,12 +1,14 @@
 package build
 
 import mill.*, androidlib.*, kotlinlib.*
+import kotlinlib.ksp.*
 import hilt.AndroidHiltSupport
 
 object Versions {
-  val kotlinVersion = "2.2.0" // Updated from 2.0.21
-  val kotlinLanguageVersion = "2.2" // Updated from 1.9
-  val kspVersion = "2.0.2" // Updated from 1.0.28
+  val kotlinVersion = "2.0.21"
+  val kotlinLanguageVersion = "1.9"
+
+  val kspVersion = "1.0.28"
   val androidCompileSdk = 35
   val androidMinSdk = 26
 }
@@ -18,7 +20,7 @@ object androidSdkModule0 extends AndroidSdkModule {
 
 // Mill configuration for the Android Todo App project.
 object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfig,
-      AndroidHiltSupport {
+      KspModule, AndroidHiltSupport {
 
   def kotlinVersion = Versions.kotlinVersion
   def kotlinLanguageVersion = Versions.kotlinLanguageVersion
@@ -68,8 +70,8 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
     mvn"org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0",
     mvn"com.jakewharton.timber:timber:5.0.1",
     mvn"androidx.test.espresso:espresso-idling-resource:3.6.1",
-    mvn"androidx.room:room-runtime:2.7.1",
-    mvn"androidx.room:room-ktx:2.7.1",
+    mvn"androidx.room:room-runtime:2.6.1",
+    mvn"androidx.room:room-ktx:2.6.1",
     mvn"androidx.activity:activity-compose:1.10.0",
     mvn"androidx.navigation:navigation-compose:2.8.5",
     mvn"androidx.emoji2:emoji2:1.3.0",
@@ -103,17 +105,11 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
   )
 
   def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-    mvn"androidx.room:room-compiler:2.7.1",
+    mvn"androidx.room:room-compiler:2.6.1",
     mvn"com.google.dagger:hilt-android-compiler:2.56"
   )
 
-  override def generatedSources = Task {
-    super[
-      AndroidHiltSupport
-    ].generatedSources() :+ generatedBuildConfig()
-  }
-
-  object test extends AndroidAppKotlinTests, AndroidHiltSupport, TestModule.Junit4 {
+  object test extends AndroidAppKotlinTests, KspModule, AndroidHiltSupport, TestModule.Junit4 {
 
     def moduleDeps = super.moduleDeps ++ Seq(`shared-test`)
 
@@ -122,7 +118,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
     override def kspVersion = Versions.kspVersion
 
     def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-      mvn"androidx.room:room-compiler:2.7.1",
+      mvn"androidx.room:room-compiler:2.6.1",
       mvn"com.google.dagger:hilt-android-compiler:2.56"
     )
 
@@ -150,7 +146,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
   }
 
   object androidTest extends AndroidAppKotlinInstrumentedTests, AndroidR8AppModule,
-        AndroidHiltSupport {
+        KspModule, AndroidHiltSupport {
 
     override def kotlinLanguageVersion = Versions.kotlinLanguageVersion
 
@@ -195,7 +191,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
       mvn"androidx.test:core-ktx:1.6.1",
       mvn"androidx.test.ext:junit-ktx:1.2.1",
       mvn"androidx.test:rules:1.6.1",
-      mvn"androidx.room:room-testing:2.7.1",
+      mvn"androidx.room:room-testing:2.6.1",
       mvn"androidx.arch.core:core-testing:2.2.0",
       mvn"androidx.navigation:navigation-testing:2.8.5",
       mvn"androidx.test.espresso:espresso-core:3.6.1",
@@ -208,7 +204,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
     )
 
     def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-      mvn"androidx.room:room-compiler:2.7.1",
+      mvn"androidx.room:room-compiler:2.6.1",
       mvn"com.google.dagger:hilt-android-compiler:2.56"
     )
 
@@ -216,7 +212,7 @@ object app extends AndroidAppKotlinModule, AndroidR8AppModule, AndroidBuildConfi
 
 }
 
-object `shared-test` extends AndroidKotlinModule, AndroidHiltSupport {
+object `shared-test` extends AndroidKotlinModule, KspModule, AndroidHiltSupport {
 
   def moduleDeps = Seq(app)
 
@@ -234,7 +230,7 @@ object `shared-test` extends AndroidKotlinModule, AndroidHiltSupport {
   def androidNamespace = "com.example.android.architecture.blueprints.todoapp.daemon.test"
 
   def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-    mvn"androidx.room:room-compiler:2.7.1",
+    mvn"androidx.room:room-compiler:2.6.1",
     mvn"com.google.dagger:hilt-android-compiler:2.56"
   )
 
@@ -248,8 +244,8 @@ object `shared-test` extends AndroidKotlinModule, AndroidHiltSupport {
     mvn"androidx.test:rules:1.6.1",
     mvn"com.google.dagger:hilt-android:2.56",
     mvn"com.google.dagger:hilt-android-testing:2.56",
-    mvn"androidx.room:room-runtime:2.7.1",
-    mvn"androidx.room:room-ktx:2.7.1"
+    mvn"androidx.room:room-runtime:2.6.1",
+    mvn"androidx.room:room-ktx:2.6.1"
   )
 }
 

--- a/libs/androidlib/src/mill/androidlib/hilt/AndroidHiltSupport.scala
+++ b/libs/androidlib/src/mill/androidlib/hilt/AndroidHiltSupport.scala
@@ -3,7 +3,7 @@ package mill.androidlib.hilt
 import mill.androidlib.AndroidKotlinModule
 import mill.api.{ModuleRef, PathRef}
 import mill.kotlinlib.DepSyntax
-import mill.kotlinlib.ksp.Ksp2Module
+import mill.kotlinlib.ksp.KspBaseModule
 import mill.javalib.Dep
 import mill.javalib.api.CompilationResult
 import mill.{T, Task}
@@ -16,12 +16,19 @@ import mill.{T, Task}
  * for pre-processing the Hilt annotations and generating the necessary classes for Hilt to work, then
  * compiles all the sources together with a Java pre-processor step and finally a transform ASM step
  * to achieve the compile time dependency injection!
+ *
+ * Usage:
+ * ```
+ *
+ * object app extends KspModule with AndroidHiltSupport { ... }
+ *
+ * // or
+ *
+ * object app extends Ksp2Module with AndroidHiltSupport { ... }
+ * ```
  */
 @mill.api.experimental
-trait AndroidHiltSupport extends Ksp2Module with AndroidKotlinModule {
-
-  override def kspLibraries: T[Seq[PathRef]] =
-    super.kspLibraries()
+trait AndroidHiltSupport extends KspBaseModule with AndroidKotlinModule {
 
   def androidHiltProcessorPath: T[Seq[PathRef]] = Task {
     kspDependencyResolver().classpath(

--- a/libs/androidlib/src/mill/androidlib/hilt/AndroidHiltSupport.scala
+++ b/libs/androidlib/src/mill/androidlib/hilt/AndroidHiltSupport.scala
@@ -2,7 +2,6 @@ package mill.androidlib.hilt
 
 import mill.androidlib.AndroidKotlinModule
 import mill.api.{ModuleRef, PathRef}
-import mill.kotlinlib.DepSyntax
 import mill.kotlinlib.ksp.KspBaseModule
 import mill.javalib.Dep
 import mill.javalib.api.CompilationResult
@@ -29,21 +28,6 @@ import mill.{T, Task}
  */
 @mill.api.experimental
 trait AndroidHiltSupport extends KspBaseModule with AndroidKotlinModule {
-
-  def androidHiltProcessorPath: T[Seq[PathRef]] = Task {
-    kspDependencyResolver().classpath(
-      kotlinSymbolProcessors().flatMap {
-        dep =>
-          if (dep.dep.module.name.value == "hilt-android-compiler")
-            Seq(
-              dep,
-              mvn"com.google.dagger:hilt-compiler:${dep.version}"
-            )
-          else
-            Seq(dep)
-      }
-    )
-  }
 
   override def kspProcessorOptions: T[Map[String, String]] = Task {
     super.kspProcessorOptions() ++ Map(

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/Ksp2Module.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/Ksp2Module.scala
@@ -36,6 +36,10 @@ trait Ksp2Module extends KspBaseModule { outer =>
     )
   }
 
+  /**
+   * The libraries that should be passed to the KSP compiler.
+   * This defaults to the compile classpath of the module.
+   */
   def kspLibraries: T[Seq[PathRef]] = compileClasspath()
 
   def kspModuleName = moduleSegments.render
@@ -48,12 +52,6 @@ trait Ksp2Module extends KspBaseModule { outer =>
     params.addVariantAttributes(
       "org.jetbrains.kotlin.platform.type" -> VariantMatcher.Equals("jvm"),
       "org.gradle.jvm.environment" -> VariantMatcher.Equals("standard-jvm")
-    )
-  }
-
-  def kotlinSymbolProcessorsResolved: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(
-      kotlinSymbolProcessors()
     )
   }
 

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspBaseModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspBaseModule.scala
@@ -1,0 +1,47 @@
+package mill.kotlinlib.ksp
+
+import mill.*
+import mill.api.{PathRef, Task}
+import mill.kotlinlib.{Dep, KotlinModule}
+
+/**
+ * Base trait for KSP (Kotlin Symbol Processing) modules.
+ * This trait defines the common interface that both KspModule and Ksp2Module implement.
+ */
+@mill.api.experimental
+trait KspBaseModule extends KotlinModule {
+
+  /**
+   * The symbol processors to be used by the Kotlin compiler.
+   * Default is empty.
+   */
+  def kotlinSymbolProcessors: T[Seq[Dep]] = Task {
+    Seq.empty[Dep]
+  }
+
+  /**
+   * Resolved classpath for the symbol processors.
+   */
+  def kotlinSymbolProcessorsResolved: T[Seq[PathRef]]
+
+  /**
+   * The classpath when running Kotlin Symbol processing.
+   */
+  def kspClasspath: T[Seq[PathRef]]
+
+  /**
+   * Processor options to be passed to KSP.
+   */
+  def kspProcessorOptions: T[Map[String, String]] = Task {
+    Map.empty[String, String]
+  }
+
+  /**
+   * Generated sources from KSP processing.
+   */
+  def generatedSourcesWithKSP: T[GeneratedKSPSources]
+
+  override def generatedSources: T[Seq[PathRef]] = Task {
+    super.generatedSources() ++ generatedSourcesWithKSP().sources
+  }
+}

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspBaseModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspBaseModule.scala
@@ -11,6 +11,10 @@ import mill.kotlinlib.{Dep, KotlinModule}
 @mill.api.experimental
 trait KspBaseModule extends KotlinModule {
 
+  def kspLanguageVersion: T[String]
+
+  def kspVersion: T[String]
+
   /**
    * The symbol processors to be used by the Kotlin compiler.
    * Default is empty.
@@ -22,7 +26,11 @@ trait KspBaseModule extends KotlinModule {
   /**
    * Resolved classpath for the symbol processors.
    */
-  def kotlinSymbolProcessorsResolved: T[Seq[PathRef]]
+  def kotlinSymbolProcessorsResolved: T[Seq[PathRef]] = Task {
+    defaultResolver().classpath(
+      kotlinSymbolProcessors()
+    )
+  }
 
   /**
    * The classpath when running Kotlin Symbol processing.

--- a/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
+++ b/libs/kotlinlib/src/mill/kotlinlib/ksp/KspModule.scala
@@ -26,7 +26,7 @@ trait KspModule extends KspBaseModule { outer =>
    * This is used to determine the KSP version to use.
    * Defaults to `1.9` which is compatible with KSP 1.x.
    */
-  def kspLanguageVersion: String = "1.9"
+  def kspLanguageVersion: T[String] = "1.9"
 
   /**
    * The version of the symbol processing library to use.
@@ -58,12 +58,6 @@ trait KspModule extends KspBaseModule { outer =>
 
   def kspPluginsResolved: T[Seq[PathRef]] = Task {
     defaultResolver().classpath(kspPlugins())
-  }
-
-  def kotlinSymbolProcessorsResolved: T[Seq[PathRef]] = Task {
-    defaultResolver().classpath(
-      kotlinSymbolProcessors()
-    )
   }
 
   override def kotlinUseEmbeddableCompiler: Task[Boolean] = Task { true }
@@ -106,7 +100,7 @@ trait KspModule extends KspBaseModule { outer =>
    * @return
    */
   def kspKotlincOptions: T[Seq[String]] = Task {
-    if (kspLanguageVersion.isBlank) {
+    if (kspLanguageVersion().isBlank) {
       throw new RuntimeException("KSP needs a compatible language version to be set!")
     }
     kotlincOptions() ++ Seq(
@@ -114,7 +108,7 @@ trait KspModule extends KspBaseModule { outer =>
       "-no-reflect",
       "-no-stdlib",
       "-language-version",
-      kspLanguageVersion
+      kspLanguageVersion()
     )
   }
 


### PR DESCRIPTION
### Consolidation
- KspModule,Ksp2Module and AndroidHiltSupport now extend KspBaseModule.
- Traits extending AndroidHiltSupport, should now extend a KspModule before AndroidHiltSupport
### Micronaut Example
- Added a micronaut example in kotlinlib/basic that tests with Ksp2ModuleKspModule,Ksp2Module and AndroidHiltSupport now extend KspBaseModule.
Traits extending AndroidHiltSupport, should now extend a KspModule before AndroidHiltSupport.