### PR TITLE
Complete Binding Logic

### DIFF
--- a/libs/androidlib/databinding-api/src/mill/androidlib/databinding/AndroidDataBinding.scala
+++ b/libs/androidlib/databinding-api/src/mill/androidlib/databinding/AndroidDataBinding.scala
@@ -2,4 +2,5 @@ package mill.androidlib.databinding
 
 trait AndroidDataBinding {
   def processResources(args: ProcessResourcesArgs): Unit
+  def generateBaseClasses(args: GenerateBaseClassesArgs): Unit
 }

--- a/libs/androidlib/databinding-api/src/mill/androidlib/databinding/AndroidDataBinding.scala
+++ b/libs/androidlib/databinding-api/src/mill/androidlib/databinding/AndroidDataBinding.scala
@@ -2,5 +2,5 @@ package mill.androidlib.databinding
 
 trait AndroidDataBinding {
   def processResources(args: ProcessResourcesArgs): Unit
-  def generateBaseClasses(args: GenerateBaseClassesArgs): Unit
+  def generateBindingSources(args: GenerateBindingSourcesArgs): Unit
 }

--- a/libs/androidlib/databinding-api/src/mill/androidlib/databinding/GenerateBaseClassesArgs.scala
+++ b/libs/androidlib/databinding-api/src/mill/androidlib/databinding/GenerateBaseClassesArgs.scala
@@ -1,3 +1,13 @@
 package mill.androidlib.databinding
 
-case class GenerateBaseClassesArgs()
+case class GenerateBaseClassesArgs(
+    applicationPackageName: String,
+    layoutInfoDir: String,
+    dependencyClassInfoDirs: Seq[String] = Seq.empty[String],
+    classInfoDir: String,
+    outputDir: String,
+    logFolder: String,
+    enableViewBinding: Boolean,
+    enableDataBinding: Boolean,
+    useAndroidX: Boolean = true
+)

--- a/libs/androidlib/databinding-api/src/mill/androidlib/databinding/GenerateBindingSources.scala
+++ b/libs/androidlib/databinding-api/src/mill/androidlib/databinding/GenerateBindingSources.scala
@@ -1,6 +1,6 @@
 package mill.androidlib.databinding
 
-case class GenerateBaseClassesArgs(
+case class GenerateBindingSourcesArgs(
     applicationPackageName: String,
     layoutInfoDir: String,
     dependencyClassInfoDirs: Seq[String] = Seq.empty[String],

--- a/libs/androidlib/databinding-api/src/mill/androidlib/databinding/ProcessResourcesArgs.scala
+++ b/libs/androidlib/databinding-api/src/mill/androidlib/databinding/ProcessResourcesArgs.scala
@@ -1,9 +1,11 @@
 package mill.androidlib.databinding
 
 case class ProcessResourcesArgs(
-      applicationPackageName: String,
-      resInputDir: String,
-      resOutputDir: String,
-      layoutInfoOutputDir: String,
-      useAndroidX: Boolean = true
+    applicationPackageName: String,
+    resInputDir: String,
+    resOutputDir: String,
+    layoutInfoOutputDir: String,
+    enableViewBinding: Boolean,
+    enableDataBinding: Boolean,
+    useAndroidX: Boolean = true
 )

--- a/libs/androidlib/databinding/src/mill/androidlib/databinding/AndroidDataBindingImpl.scala
+++ b/libs/androidlib/databinding/src/mill/androidlib/databinding/AndroidDataBindingImpl.scala
@@ -24,7 +24,7 @@ class AndroidDataBindingImpl extends AndroidDataBinding {
 
   }
 
-  def generateBaseClasses(args: GenerateBaseClassesArgs): Unit = {
+  def generateBindingSources(args: GenerateBindingSourcesArgs): Unit = {
     val args0 = new LayoutInfoInput.Args(
       Seq.empty[File].toList.asJava,
       Seq.empty[File].toList.asJava,

--- a/libs/androidlib/package.mill
+++ b/libs/androidlib/package.mill
@@ -86,16 +86,16 @@ object `package` extends MillPublishScalaModule with BuildInfo {
       Deps.androidDataBindingCompiler,
       Deps.androidDataBindingCompilerCommon,
       Deps.osLib,
+      mvn"org.jetbrains.kotlin:kotlin-stdlib:1.9.10"
     )
 
     override def mvnDeps = Seq(
       mvn"com.squareup:javapoet:1.13.0",
-      mvn"javax.xml.bind:jaxb-api:2.3.1",
+      mvn"javax.xml.bind:jaxb-api:2.3.1"
     )
 
   }
 
-  object `databinding-api` extends MillAndroidModule {
-  }
+  object `databinding-api` extends MillAndroidModule {}
 
 }

--- a/libs/androidlib/src/mill/androidlib/AndroidDataBindingModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidDataBindingModule.scala
@@ -3,7 +3,7 @@ package mill.androidlib
 import mill.androidlib.databinding.{
   AndroidDataBinding,
   ProcessResourcesArgs,
-  GenerateBaseClassesArgs
+  GenerateBindingSourcesArgs
 }
 import mill.api.Task
 import mill.api.Task.Worker
@@ -105,7 +105,7 @@ trait AndroidDataBindingModule extends AndroidKotlinModule {
     os.makeDir.all(logDir)
     os.makeDir.all(outputDir)
     os.makeDir.all(classInfoDir)
-    val args = GenerateBaseClassesArgs(
+    val args = GenerateBindingSourcesArgs(
       applicationPackageName = androidNamespace,
       layoutInfoDir = (processedLayoutXmls().path / "layout_info").toString,
       classInfoDir = classInfoDir.toString,
@@ -115,7 +115,7 @@ trait AndroidDataBindingModule extends AndroidKotlinModule {
       enableDataBinding = enableDataBinding()
     )
 
-    androidDatabindingModule().generateBaseClasses(args)
+    androidDatabindingModule().generateBindingSources(args)
 
     PathRef(Task.dest)
   }

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -272,6 +272,10 @@ trait AndroidModule extends JavaModule { outer =>
    */
   def androidResources: T[Seq[PathRef]] = Task.Sources("src/main/res")
 
+  def processedAndroidResources: T[Seq[PathRef]] = Task {
+    ???
+  }
+
   /**
    * Constructs the run classpath by extracting JARs from AAR files where
    * applicable using [[androidResolvedRunMvnDeps]]
@@ -561,8 +565,12 @@ trait AndroidModule extends JavaModule { outer =>
    */
   def androidCompiledModuleResources: T[Seq[PathRef]] = Task {
 
-    val moduleResources: Seq[os.Path] =
-      androidResources().map(_.path).filter(os.exists)
+    val moduleResources: Seq[os.Path] = {
+      if (enableDataBinding() || enableViewBinding()) {
+        processedAndroidResources().map(_.path)
+      } else
+        androidResources().map(_.path).filter(os.exists)
+    }
 
     val aapt2Compile = Seq(androidSdkModule().aapt2Exe().path.toString(), "compile")
 
@@ -710,6 +718,14 @@ trait AndroidModule extends JavaModule { outer =>
   /** Optional baseline profile for ART rewriting */
   def baselineProfile: T[Option[PathRef]] = Task {
     None
+  }
+
+  def enableViewBinding: T[Boolean] = Task {
+    false
+  }
+
+  def enableDataBinding: T[Boolean] = Task {
+    false
   }
 
   trait AndroidTestModule extends JavaTests, AndroidModule {

--- a/libs/androidlib/src/mill/androidlib/AndroidModule.scala
+++ b/libs/androidlib/src/mill/androidlib/AndroidModule.scala
@@ -272,10 +272,6 @@ trait AndroidModule extends JavaModule { outer =>
    */
   def androidResources: T[Seq[PathRef]] = Task.Sources("src/main/res")
 
-  def processedAndroidResources: T[Seq[PathRef]] = Task {
-    ???
-  }
-
   /**
    * Constructs the run classpath by extracting JARs from AAR files where
    * applicable using [[androidResolvedRunMvnDeps]]
@@ -565,12 +561,8 @@ trait AndroidModule extends JavaModule { outer =>
    */
   def androidCompiledModuleResources: T[Seq[PathRef]] = Task {
 
-    val moduleResources: Seq[os.Path] = {
-      if (enableDataBinding() || enableViewBinding()) {
-        processedAndroidResources().map(_.path)
-      } else
-        androidResources().map(_.path).filter(os.exists)
-    }
+    val moduleResources: Seq[os.Path] =
+      androidResources().map(_.path).filter(os.exists)
 
     val aapt2Compile = Seq(androidSdkModule().aapt2Exe().path.toString(), "compile")
 
@@ -718,14 +710,6 @@ trait AndroidModule extends JavaModule { outer =>
   /** Optional baseline profile for ART rewriting */
   def baselineProfile: T[Option[PathRef]] = Task {
     None
-  }
-
-  def enableViewBinding: T[Boolean] = Task {
-    false
-  }
-
-  def enableDataBinding: T[Boolean] = Task {
-    false
   }
 
   trait AndroidTestModule extends JavaTests, AndroidModule {

--- a/mill-build/src/millbuild/Deps.scala
+++ b/mill-build/src/millbuild/Deps.scala
@@ -217,7 +217,8 @@ object Deps {
 
   val androidTools = mvn"com.android.tools.build:gradle:8.9.1"
   val androidDataBindingCompiler = mvn"androidx.databinding:databinding-compiler:8.13.0"
-  val androidDataBindingCompilerCommon = mvn"androidx.databinding:databinding-compiler-common:8.13.0"
+  val androidDataBindingCompilerCommon =
+    mvn"androidx.databinding:databinding-compiler-common:8.13.0"
   val hiltGradlePlugin = mvn"com.google.dagger:hilt-android-gradle-plugin:2.56"
 
   val sbt = mvn"org.scala-sbt:sbt:1.10.10"


### PR DESCRIPTION
Completes `generateBindingSources` logic.

### POW (Jetchat)
<img width="426" height="958" alt="image" src="https://github.com/user-attachments/assets/55704b5c-bcf9-4ccb-9020-a276378bbc85" />


### TODO:
- Add documentations
- Include  Jetchat in `build.mill` of thirdparty compose examples ([Ref](https://github.com/vaslabs-ltd/compose-samples-with-mill/commit/5116f173079ba154f30ac6e15a9224996af1459d))