### PR TITLE
Quarkus native tests fixes

### DIFF
--- a/libs/javalib/api/src/mill/javalib/quarkus/ApplicationModelWorker.scala
+++ b/libs/javalib/api/src/mill/javalib/quarkus/ApplicationModelWorker.scala
@@ -78,13 +78,17 @@ object ApplicationModelWorker {
     case NativeTests
   }
 
-  case class QuarkusApp(buildOutput: PathRef, runJar: PathRef, nativePath: Option[PathRef])
+  case class QuarkusApp(buildOutput: PathRef, runJar: Option[PathRef], nativePath: Option[PathRef])
       derives ReadWriter
 
   object QuarkusApp {
 
-    def apply(buildOutput: os.Path, runJar: os.Path, nativePath: Option[os.Path]): QuarkusApp =
-      new QuarkusApp(PathRef(buildOutput), PathRef(runJar), nativePath.map(PathRef(_)))
+    def apply(
+        buildOutput: os.Path,
+        runJar: Option[os.Path],
+        nativePath: Option[os.Path]
+    ): QuarkusApp =
+      new QuarkusApp(PathRef(buildOutput), runJar.map(PathRef(_)), nativePath.map(PathRef(_)))
 
   }
 }

--- a/libs/javalib/quarkus-worker/src/mill/javalib/quarkus/ApplicationModelWorkerImpl.scala
+++ b/libs/javalib/quarkus-worker/src/mill/javalib/quarkus/ApplicationModelWorkerImpl.scala
@@ -82,7 +82,7 @@ class ApplicationModelWorkerImpl extends ApplicationModelWorker {
 
     val quarkusApp = ApplicationModelWorker.QuarkusApp(
       destRunJar,
-      os.Path(app.getJar.getPath),
+      Option(app.getJar).map(j => os.Path(j.getPath)),
       Option(app.getNativeResult).map(os.Path(_))
     )
     quarkusApp

--- a/libs/javalib/src/mill/javalib/quarkus/QuarkusModule.scala
+++ b/libs/javalib/src/mill/javalib/quarkus/QuarkusModule.scala
@@ -402,9 +402,8 @@ trait QuarkusModule extends JavaModule { outer =>
     )
   }
 
-  def writeBuildPropertiesFile(native: Boolean): Task[PathRef] = Task.Anon {
-    val file = Task.dest / "quarkus-build.properties"
-    val props = if (native) quarkusNativeBuildProperties() else quarkusJarBuildProperties()
+  private def writeBuildPropertiesFile(destDir: os.Path, props: Map[String, String]): PathRef = {
+    val file = destDir / "quarkus-build.properties"
     val properties = new Properties()
     props.foreach { case (key, value) => properties.put(key, value) }
     Using(os.write.outputStream(file))(out =>
@@ -414,11 +413,11 @@ trait QuarkusModule extends JavaModule { outer =>
   }
 
   def quarkusJarBuildPropertiesFile: T[PathRef] = Task {
-    writeBuildPropertiesFile(native = false)()
+    writeBuildPropertiesFile(Task.dest, quarkusJarBuildProperties())
   }
 
   def quarkusNativeBuildPropertiesFile: T[PathRef] = Task {
-    writeBuildPropertiesFile(native = true)()
+    writeBuildPropertiesFile(Task.dest, quarkusNativeBuildProperties())
   }
 
   /**

--- a/libs/javalib/src/mill/javalib/quarkus/QuarkusModule.scala
+++ b/libs/javalib/src/mill/javalib/quarkus/QuarkusModule.scala
@@ -71,9 +71,11 @@ trait QuarkusModule extends JavaModule { outer =>
       ))
   }
 
-  override def bomMvnDeps: Task.Simple[Seq[Dep]] = super.bomMvnDeps() ++ Seq(
-    mvn"io.quarkus.platform:quarkus-bom:${quarkusPlatformVersion()}"
-  )
+  override def bomMvnDeps: T[Seq[Dep]] = Task {
+    super.bomMvnDeps() ++ Seq(
+      mvn"io.quarkus.platform:quarkus-bom:${quarkusPlatformVersion()}"
+    )
+  }
 
   /**
    * Dependencies for the Quarkus Bootstrap process
@@ -363,33 +365,64 @@ trait QuarkusModule extends JavaModule { outer =>
   }
 
   /**
+   * The properties for building a jar-based Quarkus App.
+   */
+  def quarkusJarBuildProperties: T[Map[String, String]] = Task {
+    Map(
+      "quarkus.native.enabled" -> "false"
+    )
+  }
+
+  /**
+   * Java home is required for native builds as we need to point to a GraalVM distribution.
+   * This task will fail if javaHome is not configured.
+   */
+  private def nativeJavaHome: T[PathRef] = Task {
+    javaHome() match {
+      case Some(p) => p
+      case None =>
+        Task.fail(
+          "javaHome is not configured but required for native builds.\n" +
+            "Set `jvmVersion` (or override `javaHome`) to point to a GraalVM distribution."
+        )
+    }
+  }
+
+  /**
    * The properties for building a native Quarkus App.
    * For more options see [[https://quarkus.io/guides/building-native-image#configuration-reference]]
    */
   def quarkusNativeBuildProperties: T[Map[String, String]] = Task {
+    val home = nativeJavaHome().path.toString
     Map(
+      "quarkus.package.jar.enabled" -> "false",
       "quarkus.native.enabled" -> "true",
-      "quarkus.native.graalvm-home" -> javaHome().get.path.toString,
-      "quarkus.native.java-home" -> javaHome().get.path.toString
+      "quarkus.native.graalvm-home" -> home,
+      "quarkus.native.java-home" -> home
     )
   }
 
-  def quarkusNativeBuildPropertiesFile: T[PathRef] = Task {
+  def writeBuildPropertiesFile(native: Boolean): Task[PathRef] = Task.Anon {
     val file = Task.dest / "quarkus-build.properties"
+    val props = if (native) quarkusNativeBuildProperties() else quarkusJarBuildProperties()
     val properties = new Properties()
-    quarkusNativeBuildProperties().foreach {
-      (key, value) => properties.put(key, value)
-    }
+    props.foreach { case (key, value) => properties.put(key, value) }
     Using(os.write.outputStream(file))(out =>
       properties.store(out, "Generated build properties by Mill")
     )
-
     PathRef(file)
   }
 
+  def quarkusJarBuildPropertiesFile: T[PathRef] = Task {
+    writeBuildPropertiesFile(native = false)()
+  }
+
+  def quarkusNativeBuildPropertiesFile: T[PathRef] = Task {
+    writeBuildPropertiesFile(native = true)()
+  }
+
   /**
-   * A quarkus app is a build with a quarkus run jar
-   * and a native path.
+   * A quarkus app built only with the jar packaging
    */
   def quarkusApp: T[ApplicationModelWorker.QuarkusApp] = Task {
     val dest = Task.dest / "quarkus"
@@ -398,7 +431,31 @@ trait QuarkusModule extends JavaModule { outer =>
       quarkusSerializedAppModel().path,
       dest,
       jar().path,
+      quarkusJarBuildPropertiesFile().path
+    )
+  }
+
+  /**
+   * A native quarkus app built with the native image packaging
+   */
+  def quarkusNativeApp: T[ApplicationModelWorker.QuarkusApp] = Task {
+    val dest = Task.dest / "quarkus-native"
+    os.makeDir.all(dest)
+    quarkusApplicationModelWorker().quarkusBootstrapApplication(
+      quarkusSerializedAppModel().path,
+      dest,
+      jar().path,
       quarkusNativeBuildPropertiesFile().path
+    )
+  }
+
+  def quarkusNativePathOpt: T[Option[PathRef]] = Task {
+    quarkusNativeApp().nativePath
+  }
+
+  def quarkusNativePath: T[PathRef] = Task {
+    quarkusNativePathOpt().getOrElse(
+      Task.fail("No native image output was produced")
     )
   }
 
@@ -456,8 +513,8 @@ trait QuarkusModule extends JavaModule { outer =>
 
     override def forkArgs: T[Seq[String]] = Task {
       Seq(
-        s"-Dbuild.output.directory=${outer.quarkusApp().buildOutput.path}",
-        s"-Dnative.image.path=${outer.quarkusApp().nativePath.get.path}"
+        s"-Dbuild.output.directory=${outer.quarkusNativeApp().buildOutput.path}",
+        s"-Dnative.image.path=${outer.quarkusNativePath().path}"
       ) ++ super.forkArgs()
     }
   }

--- a/libs/javalib/src/mill/javalib/quarkus/QuarkusModule.scala
+++ b/libs/javalib/src/mill/javalib/quarkus/QuarkusModule.scala
@@ -459,6 +459,10 @@ trait QuarkusModule extends JavaModule { outer =>
     )
   }
 
+  def quarkusRunJarOpt: T[Option[PathRef]] = Task {
+    quarkusApp().runJar
+  }
+
   /**
    * The quarkus-run.jar which is a standalone fast jar
    * created by QuarkusBootstrap using the generated ApplicationModel
@@ -466,7 +470,9 @@ trait QuarkusModule extends JavaModule { outer =>
    * @return the path of the quarkus-run.jar
    */
   def quarkusRunJar: T[PathRef] = Task {
-    quarkusApp().runJar
+    quarkusRunJarOpt().getOrElse(
+      Task.fail("No quarkus-run.jar was produced")
+    )
   }
 
   trait QuarkusTests extends QuarkusModule, JavaTests { qt =>


### PR DESCRIPTION
Since we need to be able to select whether a runjar or a native build is produced, this makes both fields an option.
Also adds helper tasks that fail verbosely if a `get` is requested on an unproduced *flavor*.